### PR TITLE
Add docs and ipopt-binary port

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-por
 
 Then, to install the `ipopt-binary` port, run `vcpkg` with the following options: 
 ~~~
-./vcpkg.exe --overlay-ports=<repo_parent_pant>/robotology-vcpkg-binary-ports install ipopt-binary:x64-windows --
+./vcpkg.exe --overlay-ports=<repo_parent_directory>/robotology-vcpkg-binary-ports install ipopt-binary:x64-windows --
 ~~~
 
 ## Available ports 
 
 | Port name | Official vcpkg triplet for which it is available | 
 |:---------:|:------------------------------------------------:|
-| [`ipopt-binary`](ipopt-binary)| `x64-windows`                               | 
+| [`ipopt-binary`](ipopt-binary)| `x64-windows`                | 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# vcpkg-binary-ports
+# robotology-vcpkg-binary-ports
 Collection of vcpkg ports available on limited platform just in binary form. 
+
+## Usage
+
+To use this repo, you will need to specify to `vcpkg` to use the ports contained in this repo using
+the [`--overlay-ports` option](https://github.com/microsoft/vcpkg/blob/master/docs/specifications/ports-overlay.md). 
+
+For example, you can first clone this repo:
+~~~
+git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports
+~~~
+
+Then, to install the `ipopt-binary` port, run `vcpkg` with the following options: 
+~~~
+./vcpkg.exe --overlay-ports=<repo_parent_pant>/robotology-vcpkg-binary-ports install ipopt-binary:x64-windows --
+~~~
+
+## Available ports 
+
+| Port name | Official vcpkg triplet for which it is available | 
+|:---------:|:------------------------------------------------:|
+| [`ipopt-binary`](ipopt-binary)| `x64-windows`                               | 

--- a/ipopt-binary/CONTROL
+++ b/ipopt-binary/CONTROL
@@ -1,0 +1,3 @@
+Source: ipopt-binary
+Version: 3.12.7
+Description: Interior point optimizer

--- a/ipopt-binary/portfile.cmake
+++ b/ipopt-binary/portfile.cmake
@@ -1,0 +1,32 @@
+include(vcpkg_common_functions)
+
+if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    message(FATAL_ERROR "This port does not currently support architecture: ${VCPKG_TARGET_ARCHITECTURE}")
+endif()
+
+# Empty VCPKG_CMAKE_SYSTEM_NAME means Windows, see https://github.com/microsoft/vcpkg/blame/2019.07/docs/users/triplets.md#L31
+if(VCPKG_CMAKE_SYSTEM_NAME) 
+    message(FATAL_ERROR "This port does not currently support system: ${VCPKG_CMAKE_SYSTEM_NAME}, only Windows 64bit is supported.")
+endif()
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "http://www.icub.org/download/3rd-party/ipopt-3.12.7_msvc14_x86_amd64.zip"
+    FILENAME "ipopt-3.12.7_msvc14_x86_amd64.zip"
+    SHA512 26b42b8f6a75a815a3b3988b828a383965e291d4c204f053591b9e05e7925aa265d055a10d771fb505ea4ed98a1e9aa2521ce9d0375afe54ee75418a39dfafc1
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE} 
+)
+
+# Just install the content directly 
+file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
+file(INSTALL ${SOURCE_PATH}/bin DESTINATION ${CURRENT_PACKAGES_DIR})
+file(INSTALL ${SOURCE_PATH}/lib DESTINATION ${CURRENT_PACKAGES_DIR})
+file(INSTALL ${SOURCE_PATH}/bin DESTINATION ${CURRENT_PACKAGES_DIR}/debug)
+file(INSTALL ${SOURCE_PATH}/lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/share/coin/doc/Ipopt/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/ipopt-binary RENAME copyright)
+


### PR DESCRIPTION
This is the first custom port added to the repo, that can be used to simplify installation of ipopt in a vcpkg-based enviroment. At the moment, the only triplet supported is `x64-windows`.

See the README for docs on how to use the port. 