### PR TITLE
Add GitHub Actions support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,14 @@ on:
   # Execute a "nightly" build at 2 AM UTC 
   - cron:  '0 2 * * *'
 
+
 jobs:
   build:
+    name: '[${{ matrix.vcpkg_version }}]'
+    strategy:  
+      fail-fast: false
+      matrix:
+        vcpkg_version: [master, 2020.01, 2019.12]
 
     runs-on: windows-latest
 
@@ -21,6 +27,8 @@ jobs:
       run: |
         mkdir C:/vcpkg-test
         git clone https://github.com/microsoft/vcpkg  C:/vcpkg-test/vcpkg
+        cd C:/vcpkg-test/vcpkg 
+        git checkout ${{ matrix.vcpkg_version }}
         C:/vcpkg-test/vcpkg/bootstrap-vcpkg.sh
         C:/vcpkg-test/vcpkg/vcpkg.exe --overlay-ports=${GITHUB_WORKSPACE} install --triplet x64-windows ipopt-binary
         # Try to install another library to check if the installation is ok

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:  
       fail-fast: false
       matrix:
-        vcpkg_version: [master, 2020.01, 2019.12]
+        vcpkg_version: [2020.01, 2019.12]
 
     runs-on: windows-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,5 @@ jobs:
         git clone https://github.com/microsoft/vcpkg  C:/vcpkg-test/vcpkg
         C:/vcpkg-test/vcpkg/bootstrap-vcpkg.sh
         C:/vcpkg-test/vcpkg/vcpkg.exe --overlay-ports=${GITHUB_WORKSPACE} install --triplet x64-windows ipopt-binary
+        # Try to install another library to check if the installation is ok
+        C:/vcpkg-test/vcpkg/vcpkg.exe install --triplet x64-windows asio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC 
+  - cron:  '0 2 * * *'
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Run on latest vcpkg 
+      shell: bash
+      run: |
+        mkdir C:/vcpkg-test
+        git clone https://github.com/microsoft/vcpkg  C:/vcpkg-test/vcpkg
+        C:/vcpkg-test/vcpkg/bootstrap-vcpkg.sh
+        C:/vcpkg-test/vcpkg/vcpkg.exe --overlay-ports=${GITHUB_WORKSPACE} install --triplet x64-windows ipopt-binary


### PR DESCRIPTION
The test always test with the latest vcpkg to quickly detect regressions.