### PR TITLE
 Add port for the ESD CAN SDK library and for the Ensenso cameras SDK 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
         cd C:/vcpkg-test/vcpkg 
         git checkout ${{ matrix.vcpkg_version }}
         C:/vcpkg-test/vcpkg/bootstrap-vcpkg.sh
-        C:/vcpkg-test/vcpkg/vcpkg.exe --overlay-ports=${GITHUB_WORKSPACE} install --triplet x64-windows ipopt-binary
+        C:/vcpkg-test/vcpkg/vcpkg.exe --overlay-ports=${GITHUB_WORKSPACE} install --triplet x64-windows esdcan-binary ensenso-binary ipopt-binary
         # Try to install another library to check if the installation is ok
         C:/vcpkg-test/vcpkg/vcpkg.exe install --triplet x64-windows asio

--- a/ensenso-binary/CONTROL
+++ b/ensenso-binary/CONTROL
@@ -1,0 +1,4 @@
+Source: ensenso-binary
+Version: 2.3.1174
+Description:  Software Development Kit (SDK) to read data from Ensenso cameras.
+Homepage: https://www.ensenso.com/support/sdk-download/

--- a/ensenso-binary/portfile.cmake
+++ b/ensenso-binary/portfile.cmake
@@ -1,0 +1,32 @@
+include(vcpkg_common_functions)
+
+if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    message(FATAL_ERROR "This port does not currently support architecture: ${VCPKG_TARGET_ARCHITECTURE}")
+endif()
+
+# Empty VCPKG_CMAKE_SYSTEM_NAME means Windows, see https://github.com/microsoft/vcpkg/blame/2019.07/docs/users/triplets.md#L31
+if(VCPKG_CMAKE_SYSTEM_NAME) 
+    message(FATAL_ERROR "This port does not currently support system: ${VCPKG_CMAKE_SYSTEM_NAME}, only Windows 64bit is supported.")
+endif()
+
+set(version 2.3.1174)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/robotology/robotology-vcpkg-binary-ports/releases/download/storage/ensenso-${version}.zip"
+    FILENAME "ensenso-${version}.zip"
+    SHA512 f72d75b2edc170a43b43d90d040fd5cada0d8329fb4685c7cb48166ef48897458e459deca8ebabed833912964298090c517cfdcfe7029498415e3f31873f7e61
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE} 
+)
+
+# Just install the content directly 
+file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
+file(INSTALL ${SOURCE_PATH}/lib DESTINATION ${CURRENT_PACKAGES_DIR})
+file(INSTALL ${SOURCE_PATH}/lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/Eula.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/ensenso-binary RENAME copyright)
+

--- a/esdcan-binary/CONTROL
+++ b/esdcan-binary/CONTROL
@@ -1,0 +1,4 @@
+Source: esdcan-binary
+Version: 6.3.0
+Description: Software Development Kit (SDK) for esd NTCAN-API.
+Homepage: https://esd.eu/en/products/can-sdk

--- a/esdcan-binary/portfile.cmake
+++ b/esdcan-binary/portfile.cmake
@@ -1,0 +1,32 @@
+include(vcpkg_common_functions)
+
+if(NOT VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+    message(FATAL_ERROR "This port does not currently support architecture: ${VCPKG_TARGET_ARCHITECTURE}")
+endif()
+
+# Empty VCPKG_CMAKE_SYSTEM_NAME means Windows, see https://github.com/microsoft/vcpkg/blame/2019.07/docs/users/triplets.md#L31
+if(VCPKG_CMAKE_SYSTEM_NAME) 
+    message(FATAL_ERROR "This port does not currently support system: ${VCPKG_CMAKE_SYSTEM_NAME}, only Windows 64bit is supported.")
+endif()
+
+set(version 6.3.0)
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/robotology/robotology-vcpkg-binary-ports/releases/download/storage/esdcan-${version}.zip"
+    FILENAME "ensenso-${version}.zip"
+    SHA512 8a98b00df1dbb5a675c1d4554d3a277844fbfd7ce60df1f8b1f72ba92200cce0dd9bb833de158be223f1bdb47322486c5bfe57d60ec84e1a6822133627ed8e84
+)
+
+vcpkg_extract_source_archive_ex(
+    OUT_SOURCE_PATH SOURCE_PATH
+    ARCHIVE ${ARCHIVE} 
+)
+
+# Just install the content directly 
+file(INSTALL ${SOURCE_PATH}/include DESTINATION ${CURRENT_PACKAGES_DIR})
+file(INSTALL ${SOURCE_PATH}/lib DESTINATION ${CURRENT_PACKAGES_DIR})
+file(INSTALL ${SOURCE_PATH}/lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug)
+
+# Handle copyright
+file(INSTALL ${SOURCE_PATH}/esd_license.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/esdcan-binary RENAME copyright)
+


### PR DESCRIPTION
This streamlines the compilation of software that depends on this proprietary libraries. 
For actually use this version of the  ESD CAN in  CMake, it is required the change https://github.com/robotology/ycm/pull/320, that still needs to be released in an official release of YCM.