### PR TITLE
Add master branch and a recent commit to vcpkg version tested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:  
       fail-fast: false
       matrix:
-        vcpkg_version: [master, 2020.01, 2019.12]
+        vcpkg_version: [master, 13f5a3d6159069d216b82695afcd21f7f0bbb827]
 
     runs-on: windows-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:  
       fail-fast: false
       matrix:
-        vcpkg_version: [2020.01, 2019.12]
+        vcpkg_version: [master, 2020.01, 2019.12]
 
     runs-on: windows-latest
 


### PR DESCRIPTION
This PR was blocked for a long time due to https://github.com/microsoft/vcpkg/issues/10119 . Now that https://github.com/microsoft/vcpkg/issues/10119 has been solved, we can test `master` and a recent fixed commit after the merge of https://github.com/microsoft/vcpkg/pull/13231  . Once a new tag is done that contains https://github.com/microsoft/vcpkg/pull/13231 is released, we can substitute this fixed checkout with the tag. 