### PR TITLE
Release 0.2.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] = 2021-05-30
+## [Unreleased]
+
+## [0.2.0] = 2021-05-29
 
 ### Added 
 - The `casadi` port has been added (https://github.com/robotology/robotology-vcpkg-ports/pull/11).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] = 2021-05-29
+## [0.2.0] - 2021-05-29
 
 ### Added 
 - The `casadi` port has been added (https://github.com/robotology/robotology-vcpkg-ports/pull/11).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] = 2021-05-30
 
-The `casadi` port has been added.
+### Added 
+- The `casadi` port has been added (https://github.com/robotology/robotology-vcpkg-ports/pull/11).
+
+### Changed 
+- The name of the repo is now `robotology-vcpkg-ports` (https://github.com/robotology/robotology-vcpkg-ports/pull/13, https://github.com/robotology/robotology-vcpkg-ports/pull/20).
+* The `ipopt-binary`  downloads the binary from GitHub (https://github.com/robotology/robotology-vcpkg-ports/pull/17).
 
 ## [0.1.1] - 2020-07-14
 
 ### Added 
-The `ipopt-binary` now installs a `Ipopt-config.cmake` file for compatibility with the [CasADi](https://web.casadi.org/) build (https://github.com/robotology/robotology-vcpkg-binary-ports/pull/10).
+- The `ipopt-binary` now installs a `Ipopt-config.cmake` file for compatibility with the [CasADi](https://web.casadi.org/) build (https://github.com/robotology/robotology-vcpkg-binary-ports/pull/10).
 
 ## [0.1.0] - 2020-03-04
 


### PR DESCRIPTION
This is required in https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/pull/45 as the CI is failing as `http://www.icub.org/download/3rd-party/ipopt-3.12.7_msvc14_x86_amd64.zip` is not  a valid URL anymore, and we need to have https://github.com/robotology/robotology-vcpkg-ports/pull/17/files in a released version.