### PR TITLE
ipopt-binary: Add ipopt imported target in Ipopt-config.cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2023-04-10
+
+### Added
+- Added `ipopt` CMake imported target in the CMake config file installed by the `ipopt-binary` (https://github.com/robotology/robotology-vcpkg-ports/pull/22).
+
 ## [0.2.0] - 2021-05-29
 
 ### Added 

--- a/ipopt-binary/Ipopt-config.cmake
+++ b/ipopt-binary/Ipopt-config.cmake
@@ -14,3 +14,11 @@ set(Ipopt_LIBRARIES  "optimized;${PACKAGE_PREFIX_DIR}/lib/libipopt.lib;debug;${P
 set(IPOPT_FOUND ON)
 set(IPOPT_INCLUDE_DIRS ${Ipopt_INCLUDE_DIR})
 set(IPOPT_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
+
+# The ipopt imported target is required by casadi's FindIPOPT
+# See https://github.com/casadi/casadi/blob/3.6.0/cmake/FindIPOPT.cmake#L47
+if(NOT TARGET ipopt)
+  add_library(ipopt INTERFACE)
+  target_link_libraries(ipopt INTERFACE ${Ipopt_LIBRARIES})
+  target_include_directories(ipopt INTERFACE ${IPOPT_INCLUDE_DIRS})
+endif()


### PR DESCRIPTION
The new FindIPOPT.cmake file shipped in casadi 3.6.0 expects the imported target to be available, otherwise it tries to parse the `Ipopt_LIBRARIES` variable, not handling correctly the `optimized` and `debug` strings.

See:
* https://github.com/casadi/casadi/blob/3.6.0/cmake/FindIPOPT.cmake#L49
* https://github.com/robotology/robotology-superbuild/pull/1379#issuecomment-1502155532
